### PR TITLE
Update GPG key in Dockerfile to fix apt-get update error

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,11 @@
 ARG BASE_IMAGE=pytorch/pytorch:1.10.0-cuda11.3-cudnn8-devel
 FROM $BASE_IMAGE
 
+# fix the GPG error:
+RUN apt-key del 7fa2af80 
+RUN apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub && \
+    apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/3bf863cc.pub
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     libglvnd0 \


### PR DESCRIPTION
The GPG keys have been updated, as mentioned in this [NVIDIA forum post](https://forums.developer.nvidia.com/t/gpg-error-http-developer-download-nvidia-com-compute-cuda-repos-ubuntu1804-x86-64/212904). Consequently, executing apt-get update during the Docker build process may result in the error below:

```
Err:6 http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease                                       
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
```
Using the updated GPG key into the Dockerfile resolves this issue.