### PR TITLE
Use torch cpp_extension load instead of `importlib.import_module`

### DIFF
--- a/nvdiffrast/__init__.py
+++ b/nvdiffrast/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.  All rights reserved.
 #
 # NVIDIA CORPORATION and its licensors retain all intellectual property
 # and proprietary rights in and to this software, related documentation
@@ -6,4 +6,4 @@
 # distribution of this software and related documentation without an express
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 
-__version__ = '0.3.3'
+__version__ = '0.3.4'

--- a/nvdiffrast/torch/ops.py
+++ b/nvdiffrast/torch/ops.py
@@ -122,11 +122,11 @@ def _get_plugin(gl=False):
 
     # Compile and load.
     source_paths = [os.path.join(os.path.dirname(__file__), fn) for fn in source_files]
-    torch.utils.cpp_extension.load(name=plugin_name, sources=source_paths, extra_cflags=common_opts+cc_opts, extra_cuda_cflags=common_opts+['-lineinfo'], extra_ldflags=ldflags, with_cuda=True, verbose=False)
+    plugin = torch.utils.cpp_extension.load(name=plugin_name, sources=source_paths, extra_cflags=common_opts+cc_opts, extra_cuda_cflags=common_opts+['-lineinfo'], extra_ldflags=ldflags, with_cuda=True, verbose=False)
 
-    # Import, cache, and return the compiled module.
-    _cached_plugin[gl] = importlib.import_module(plugin_name)
-    return _cached_plugin[gl]
+    # Cache, and return the compiled module.
+    _cached_plugin[gl] = plugin
+    return plugin
 
 #----------------------------------------------------------------------------
 # Log level.


### PR DESCRIPTION
Use the torch extension module returned by `torch.utils.cpp_extension.load` instead of loading via `importlib.import_module`.

This works around the case when the extension cache directory may not be in `PYTHONPATH` and therefore not found by `importlib` despite having just been compiled.

I bumped patch version, LMK if you have a different release process.