### PR TITLE
Feature: border_mode `values`

### DIFF
--- a/csrc/common/texture.h
+++ b/csrc/common/texture.h
@@ -31,37 +31,40 @@
 #define TEX_BOUNDARY_MODE_WRAP                  1   // Wrap (u, v).
 #define TEX_BOUNDARY_MODE_CLAMP                 2   // Clamp (u, v).
 #define TEX_BOUNDARY_MODE_ZERO                  3   // Pad with zeros.
-#define TEX_BOUNDARY_MODE_COUNT                 4
+#define TEX_BOUNDARY_MODE_VALUES                4   // Pad with user-defined values.
+#define TEX_BOUNDARY_MODE_COUNT                 5
+#define TEX_MAX_BORDER_VALUES                   16 // Maximum number of values for TEX_BOUNDARY_MODE_VALUES.
 
 //------------------------------------------------------------------------
 // CUDA kernel params.
 
 struct TextureKernelParams
 {
-    const float*    tex[TEX_MAX_MIP_LEVEL];         // Incoming texture buffer with mip levels.
-    const float*    uv;                             // Incoming texcoord buffer.
-    const float*    uvDA;                           // Incoming uv pixel diffs or NULL.
-    const float*    mipLevelBias;                   // Incoming mip level bias or NULL.
-    const float*    dy;                             // Incoming output gradient.
-    float*          out;                            // Outgoing texture data.
-    float*          gradTex[TEX_MAX_MIP_LEVEL];     // Outgoing texture gradients with mip levels.
-    float*          gradUV;                         // Outgoing texcoord gradient.
-    float*          gradUVDA;                       // Outgoing texcoord pixel differential gradient.
-    float*          gradMipLevelBias;               // Outgoing mip level bias gradient.
-    int             enableMip;                      // If true, we have uv_da and/or mip_level_bias input(s), and a mip tensor.
-    int             filterMode;                     // One of the TEX_MODE_ constants.
-    int             boundaryMode;                   // One of the TEX_BOUNDARY_MODE_ contants.
-    int             texConst;                       // If true, texture is known to be constant.
-    int             mipLevelLimit;                  // Mip level limit coming from the op.
-    int             channels;                       // Number of texture channels.
-    int             imgWidth;                       // Image width.
-    int             imgHeight;                      // Image height.
-    int             texWidth;                       // Texture width.
-    int             texHeight;                      // Texture height.
-    int             texDepth;                       // Texture depth.
-    int             n;                              // Minibatch size.
-    int             mipLevelMax;                    // Maximum mip level index. Zero if mips disabled.
-    int             mipLevelOut;                    // Mip level being calculated in builder kernel.
+    const float*    tex[TEX_MAX_MIP_LEVEL];              // Incoming texture buffer with mip levels.
+    const float*    uv;                                  // Incoming texcoord buffer.
+    const float*    uvDA;                                // Incoming uv pixel diffs or NULL.
+    const float*    mipLevelBias;                        // Incoming mip level bias or NULL.
+    const float*    dy;                                  // Incoming output gradient.
+    float*          out;                                 // Outgoing texture data.
+    float*          gradTex[TEX_MAX_MIP_LEVEL];          // Outgoing texture gradients with mip levels.
+    float*          gradUV;                              // Outgoing texcoord gradient.
+    float*          gradUVDA;                            // Outgoing texcoord pixel differential gradient.
+    float*          gradMipLevelBias;                    // Outgoing mip level bias gradient.
+    int             enableMip;                           // If true, we have uv_da and/or mip_level_bias input(s), and a mip tensor.
+    int             filterMode;                          // One of the TEX_MODE_ constants.
+    int             boundaryMode;                        // One of the TEX_BOUNDARY_MODE_ contants.
+    float           borderValues[TEX_MAX_BORDER_VALUES]; // Border values for TEX_BOUNDARY_MODE_VALUES (one per channel)
+    int             texConst;                            // If true, texture is known to be constant.
+    int             mipLevelLimit;                       // Mip level limit coming from the op.
+    int             channels;                            // Number of texture channels.
+    int             imgWidth;                            // Image width.
+    int             imgHeight;                           // Image height.
+    int             texWidth;                            // Texture width.
+    int             texHeight;                           // Texture height.
+    int             texDepth;                            // Texture depth.
+    int             n;                                   // Minibatch size.
+    int             mipLevelMax;                         // Maximum mip level index. Zero if mips disabled.
+    int             mipLevelOut;                         // Mip level being calculated in builder kernel.
 };
 
 //------------------------------------------------------------------------

--- a/csrc/common/texture_kernel.cu
+++ b/csrc/common/texture_kernel.cu
@@ -352,8 +352,8 @@ static __device__ __forceinline__ int indexTextureNearest(const TextureKernelPar
     int iu = __float2int_rd(u);
     int iv = __float2int_rd(v);
 
-    // In zero boundary mode, return texture address -1.
-    if (!CUBE_MODE && p.boundaryMode == TEX_BOUNDARY_MODE_ZERO)
+    // In zero/values boundary mode, return texture address -1.
+    if (!CUBE_MODE && (p.boundaryMode == TEX_BOUNDARY_MODE_ZERO || p.boundaryMode == TEX_BOUNDARY_MODE_VALUES))
     {
         if (iu < 0 || iu >= w || iv < 0 || iv >= h)
             return -1;
@@ -454,8 +454,8 @@ static __device__ __forceinline__ float2 indexTextureLinear(const TextureKernelP
     tcOut.z = iu0z + w * iv1;
     tcOut.w = iu1z + w * iv1;
 
-    // Invalidate texture addresses outside unit square if we are in zero mode.
-    if (!CUBE_MODE && p.boundaryMode == TEX_BOUNDARY_MODE_ZERO)
+    // Invalidate texture addresses outside unit square if we are in zero/values mode.
+    if (!CUBE_MODE && (p.boundaryMode == TEX_BOUNDARY_MODE_ZERO || p.boundaryMode == TEX_BOUNDARY_MODE_VALUES))
     {
         bool iu0_out = (iu0 < 0 || iu0 >= w);
         bool iu1_out = (iu1 < 0 || iu1 >= w);
@@ -588,12 +588,12 @@ static __device__ __forceinline__ void calculateMipLevel(int& level0, int& level
 // Texel fetch and accumulator helpers that understand cube map corners.
 
 template<class T>
-static __device__ __forceinline__ void fetchQuad(T& a00, T& a10, T& a01, T& a11, const float* pIn, int4 tc, bool corner)
+static __device__ __forceinline__ void fetchQuad(T& a00, T& a10, T& a01, T& a11, const float* pIn, int4 tc, bool corner, const T borderValue)
 {
-    // For invalid cube map uv, tc will be all negative, and all texel values will be zero.
+    // For invalid cube map uv, tc will be all negative, and all texel values will be zero (borderValue will be zero for boundary mode TEX_BOUNDARY_MODE_CUBE).
     if (corner)
     {
-        T avg = zero_value<T>();
+        T avg = borderValue;
         if (tc.x >= 0) avg += (a00 = *((const T*)&pIn[tc.x]));
         if (tc.y >= 0) avg += (a10 = *((const T*)&pIn[tc.y]));
         if (tc.z >= 0) avg += (a01 = *((const T*)&pIn[tc.z]));
@@ -606,10 +606,10 @@ static __device__ __forceinline__ void fetchQuad(T& a00, T& a10, T& a01, T& a11,
     }
     else
     {
-        a00 = (tc.x >= 0) ? *((const T*)&pIn[tc.x]) : zero_value<T>();
-        a10 = (tc.y >= 0) ? *((const T*)&pIn[tc.y]) : zero_value<T>();
-        a01 = (tc.z >= 0) ? *((const T*)&pIn[tc.z]) : zero_value<T>();
-        a11 = (tc.w >= 0) ? *((const T*)&pIn[tc.w]) : zero_value<T>();
+        a00 = (tc.x >= 0) ? *((const T*)&pIn[tc.x]) : borderValue;
+        a10 = (tc.y >= 0) ? *((const T*)&pIn[tc.y]) : borderValue;
+        a01 = (tc.z >= 0) ? *((const T*)&pIn[tc.z]) : borderValue;
+        a11 = (tc.w >= 0) ? *((const T*)&pIn[tc.w]) : borderValue;
     }
 }
 
@@ -706,6 +706,23 @@ __global__ void MipBuildKernel4(const TextureKernelParams p) { MipBuildKernelTem
 //------------------------------------------------------------------------
 // Forward kernel.
 
+template<class T>
+__device__ __forceinline__ T border_value(const TextureKernelParams& p, const int c);
+
+template<> __device__ __forceinline__ float  border_value<float> (const TextureKernelParams& p, const int c) 
+{ 
+    return p.boundaryMode == TEX_BOUNDARY_MODE_VALUES ? p.borderValues[c] : zero_value<float>(); 
+}
+template<> __device__ __forceinline__ float2 border_value<float2>(const TextureKernelParams& p, const int c) 
+{ 
+    return p.boundaryMode == TEX_BOUNDARY_MODE_VALUES ? make_float2(p.borderValues[c], p.borderValues[c+1]) : zero_value<float2>(); 
+}
+template<> __device__ __forceinline__ float4 border_value<float4>(const TextureKernelParams& p, const int c) 
+{ 
+    return p.boundaryMode == TEX_BOUNDARY_MODE_VALUES ? make_float4(p.borderValues[c], p.borderValues[c+1], p.borderValues[c+2], p.borderValues[c+3]) : zero_value<float4>(); 
+}
+
+
 template <class T, int C, bool CUBE_MODE, bool BIAS_ONLY, int FILTER_MODE>
 static __forceinline__ __device__ void TextureFwdKernelTemplate(const TextureKernelParams p)
 {
@@ -737,9 +754,9 @@ static __forceinline__ __device__ void TextureFwdKernelTemplate(const TextureKer
         tc *= p.channels;
         const float* pIn = p.tex[0];
 
-        // Copy if valid tc, otherwise output zero.
+        // Copy if valid tc, otherwise output the border value.
         for (int i=0; i < p.channels; i += C)
-            *((T*)&pOut[i]) = (tc >= 0) ? *((const T*)&pIn[tc + i]) : zero_value<T>();
+            *((T*)&pOut[i]) = (tc >= 0) ? *((const T*)&pIn[tc + i]) : border_value<T>(p, i);
 
         return; // Exit.
     }
@@ -764,7 +781,7 @@ static __forceinline__ __device__ void TextureFwdKernelTemplate(const TextureKer
         for (int i=0; i < p.channels; i += C, tc0 += C)
         {
             T a00, a10, a01, a11;
-            fetchQuad<T>(a00, a10, a01, a11, pIn0, tc0, corner0);
+            fetchQuad<T>(a00, a10, a01, a11, pIn0, tc0, corner0, border_value<T>(p, i));
             *((T*)&pOut[i]) = bilerp(a00, a10, a01, a11, uv0);
         }
         return; // Exit.
@@ -782,14 +799,14 @@ static __forceinline__ __device__ void TextureFwdKernelTemplate(const TextureKer
     {
         // First level.
         T a00, a10, a01, a11;
-        fetchQuad<T>(a00, a10, a01, a11, pIn0, tc0, corner0);
+        fetchQuad<T>(a00, a10, a01, a11, pIn0, tc0, corner0, border_value<T>(p, i));
         T a = bilerp(a00, a10, a01, a11, uv0);
 
         // Second level unless in magnification mode.
         if (flevel > 0.f)
         {
             T b00, b10, b01, b11;
-            fetchQuad<T>(b00, b10, b01, b11, pIn1, tc1, corner1);
+            fetchQuad<T>(b00, b10, b01, b11, pIn1, tc1, corner1, border_value<T>(p, i));
             T b = bilerp(b00, b10, b01, b11, uv1);
             a = lerp(a, b, flevel); // Interpolate between levels.
         }
@@ -1035,7 +1052,7 @@ static __forceinline__ __device__ void TextureGradKernelTemplate(const TextureKe
             accumQuad(tw0 * dy, pOut0, level0, tc0, corner0, CA_TEMP);
 
             float a00, a10, a01, a11;
-            fetchQuad<float>(a00, a10, a01, a11, pIn0, tc0, corner0);
+            fetchQuad<float>(a00, a10, a01, a11, pIn0, tc0, corner0, border_value<float>(p, i));
             float ad = (a11 + a00 - a10 - a01);
             gu += dy * ((a10 - a00) + uv0.y * ad) * sclu0;
             gv += dy * ((a01 - a00) + uv0.x * ad) * sclv0;
@@ -1082,7 +1099,7 @@ static __forceinline__ __device__ void TextureGradKernelTemplate(const TextureKe
 
         // UV gradients for first level.
         float a00, a10, a01, a11;
-        fetchQuad<float>(a00, a10, a01, a11, pIn0, tc0, corner0);
+        fetchQuad<float>(a00, a10, a01, a11, pIn0, tc0, corner0, border_value<float>(p, i));
         float ad = (a11 + a00 - a10 - a01);
         gu += dy0 * ((a10 - a00) + uv0.y * ad) * sclu0;
         gv += dy0 * ((a01 - a00) + uv0.x * ad) * sclv0;
@@ -1096,7 +1113,7 @@ static __forceinline__ __device__ void TextureGradKernelTemplate(const TextureKe
 
             // UV gradients for second level.
             float b00, b10, b01, b11;
-            fetchQuad<float>(b00, b10, b01, b11, pIn1, tc1, corner1);
+            fetchQuad<float>(b00, b10, b01, b11, pIn1, tc1, corner1, border_value<float>(p, i));
             float bd = (b11 + b00 - b10 - b01);
             gu += dy1 * ((b10 - b00) + uv1.y * bd) * sclu1;
             gv += dy1 * ((b01 - b00) + uv1.x * bd) * sclv1;

--- a/csrc/torch/torch_bindings.cpp
+++ b/csrc/torch/torch_bindings.cpp
@@ -28,12 +28,12 @@ OP_RETURN_TT        interpolate_fwd_da                  (torch::Tensor attr, tor
 OP_RETURN_TT        interpolate_grad                    (torch::Tensor attr, torch::Tensor rast, torch::Tensor tri, torch::Tensor dy);
 OP_RETURN_TTT       interpolate_grad_da                 (torch::Tensor attr, torch::Tensor rast, torch::Tensor tri, torch::Tensor dy, torch::Tensor rast_db, torch::Tensor dda, bool diff_attrs_all, std::vector<int>& diff_attrs_vec);
 TextureMipWrapper   texture_construct_mip               (torch::Tensor tex, int max_mip_level, bool cube_mode);
-OP_RETURN_T         texture_fwd                         (torch::Tensor tex, torch::Tensor uv, int filter_mode, int boundary_mode);
-OP_RETURN_T         texture_fwd_mip                     (torch::Tensor tex, torch::Tensor uv, torch::Tensor uv_da, torch::Tensor mip_level_bias, TextureMipWrapper mip_wrapper, std::vector<torch::Tensor> mip_stack, int filter_mode, int boundary_mode);
-OP_RETURN_T         texture_grad_nearest                (torch::Tensor tex, torch::Tensor uv, torch::Tensor dy, int filter_mode, int boundary_mode);
-OP_RETURN_TT        texture_grad_linear                 (torch::Tensor tex, torch::Tensor uv, torch::Tensor dy, int filter_mode, int boundary_mode);
-OP_RETURN_TTV       texture_grad_linear_mipmap_nearest  (torch::Tensor tex, torch::Tensor uv, torch::Tensor dy, torch::Tensor uv_da, torch::Tensor mip_level_bias, TextureMipWrapper mip_wrapper, std::vector<torch::Tensor> mip_stack, int filter_mode, int boundary_mode);
-OP_RETURN_TTTTV     texture_grad_linear_mipmap_linear   (torch::Tensor tex, torch::Tensor uv, torch::Tensor dy, torch::Tensor uv_da, torch::Tensor mip_level_bias, TextureMipWrapper mip_wrapper, std::vector<torch::Tensor> mip_stack, int filter_mode, int boundary_mode);
+OP_RETURN_T         texture_fwd                         (torch::Tensor tex, torch::Tensor uv, int filter_mode, int boundary_mode, std::vector<float> border_values);
+OP_RETURN_T         texture_fwd_mip                     (torch::Tensor tex, torch::Tensor uv, torch::Tensor uv_da, torch::Tensor mip_level_bias, TextureMipWrapper mip_wrapper, std::vector<torch::Tensor> mip_stack, int filter_mode, int boundary_mode, std::vector<float> border_values);
+OP_RETURN_T         texture_grad_nearest                (torch::Tensor tex, torch::Tensor uv, torch::Tensor dy, int filter_mode, int boundary_mode, std::vector<float> border_values);
+OP_RETURN_TT        texture_grad_linear                 (torch::Tensor tex, torch::Tensor uv, torch::Tensor dy, int filter_mode, int boundary_mode, std::vector<float> border_values);
+OP_RETURN_TTV       texture_grad_linear_mipmap_nearest  (torch::Tensor tex, torch::Tensor uv, torch::Tensor dy, torch::Tensor uv_da, torch::Tensor mip_level_bias, TextureMipWrapper mip_wrapper, std::vector<torch::Tensor> mip_stack, int filter_mode, int boundary_mode, std::vector<float> border_values);
+OP_RETURN_TTTTV     texture_grad_linear_mipmap_linear   (torch::Tensor tex, torch::Tensor uv, torch::Tensor dy, torch::Tensor uv_da, torch::Tensor mip_level_bias, TextureMipWrapper mip_wrapper, std::vector<torch::Tensor> mip_stack, int filter_mode, int boundary_mode, std::vector<float> border_values);
 TopologyHashWrapper antialias_construct_topology_hash   (torch::Tensor tri);
 OP_RETURN_TT        antialias_fwd                       (torch::Tensor color, torch::Tensor rast, torch::Tensor pos, torch::Tensor tri, TopologyHashWrapper topology_hash);
 OP_RETURN_TT        antialias_grad                      (torch::Tensor color, torch::Tensor rast, torch::Tensor pos, torch::Tensor tri, torch::Tensor dy, torch::Tensor work_buffer);

--- a/csrc/torch/torch_texture.cpp
+++ b/csrc/torch/torch_texture.cpp
@@ -171,7 +171,7 @@ TextureMipWrapper texture_construct_mip(torch::Tensor tex, int max_mip_level, bo
 //------------------------------------------------------------------------
 // Forward op.
 
-torch::Tensor texture_fwd_mip(torch::Tensor tex, torch::Tensor uv, torch::Tensor uv_da, torch::Tensor mip_level_bias, TextureMipWrapper mip_wrapper, std::vector<torch::Tensor> mip_stack, int filter_mode, int boundary_mode)
+torch::Tensor texture_fwd_mip(torch::Tensor tex, torch::Tensor uv, torch::Tensor uv_da, torch::Tensor mip_level_bias, TextureMipWrapper mip_wrapper, std::vector<torch::Tensor> mip_stack, int filter_mode, int boundary_mode, std::vector<float> border_values)
 {
     const at::cuda::OptionalCUDAGuard device_guard(device_of(tex));
     cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -266,6 +266,16 @@ torch::Tensor texture_fwd_mip(torch::Tensor tex, torch::Tensor uv, torch::Tensor
     p.uv = uv.data_ptr<float>();
     p.uvDA = (p.enableMip && has_uv_da) ? uv_da.data_ptr<float>() : NULL;
     p.mipLevelBias = (p.enableMip && has_mip_level_bias) ? mip_level_bias.data_ptr<float>() : NULL;
+
+    // Set border values (if provided)
+    if (p.boundaryMode == TEX_BOUNDARY_MODE_VALUES)
+    {
+        NVDR_CHECK(p.channels <= TEX_MAX_BORDER_VALUES, "boundary_mode 'values' can only be used for up to 16 channels");
+        NVDR_CHECK(p.channels == border_values.size(), "number of border values must be equal to the number of channels");
+
+        for (int i = 0; i < p.channels; ++i)
+            p.borderValues[i] = border_values[i];
+    }
 
     // Allocate output tensor.
     torch::TensorOptions opts = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
@@ -408,17 +418,17 @@ torch::Tensor texture_fwd_mip(torch::Tensor tex, torch::Tensor uv, torch::Tensor
 }
 
 // Version without mipmaps.
-torch::Tensor texture_fwd(torch::Tensor tex, torch::Tensor uv, int filter_mode, int boundary_mode)
+torch::Tensor texture_fwd(torch::Tensor tex, torch::Tensor uv, int filter_mode, int boundary_mode, std::vector<float> border_values)
 {
     torch::Tensor empty_tensor;
     std::vector<torch::Tensor> empty_vector;
-    return texture_fwd_mip(tex, uv, empty_tensor, empty_tensor, TextureMipWrapper(), empty_vector, filter_mode, boundary_mode);
+    return texture_fwd_mip(tex, uv, empty_tensor, empty_tensor, TextureMipWrapper(), empty_vector, filter_mode, boundary_mode, border_values);
 }
 
 //------------------------------------------------------------------------
 // Gradient op.
 
-std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, std::vector<torch::Tensor> > texture_grad_linear_mipmap_linear(torch::Tensor tex, torch::Tensor uv, torch::Tensor dy, torch::Tensor uv_da, torch::Tensor mip_level_bias, TextureMipWrapper mip_wrapper, std::vector<torch::Tensor> mip_stack, int filter_mode, int boundary_mode)
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, std::vector<torch::Tensor> > texture_grad_linear_mipmap_linear(torch::Tensor tex, torch::Tensor uv, torch::Tensor dy, torch::Tensor uv_da, torch::Tensor mip_level_bias, TextureMipWrapper mip_wrapper, std::vector<torch::Tensor> mip_stack, int filter_mode, int boundary_mode, std::vector<float> border_values)
 {
     const at::cuda::OptionalCUDAGuard device_guard(device_of(tex));
     cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -518,6 +528,17 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, std::vect
     p.dy = dy_.data_ptr<float>();
     p.uvDA = (p.enableMip && has_uv_da) ? uv_da.data_ptr<float>() : NULL;
     p.mipLevelBias = (p.enableMip && has_mip_level_bias) ? mip_level_bias.data_ptr<float>() : NULL;
+
+    // Set border values (if provided)
+    if (p.boundaryMode == TEX_BOUNDARY_MODE_VALUES)
+    {
+        NVDR_CHECK(p.channels <= TEX_MAX_BORDER_VALUES, "boundary_mode 'values' can only be used for up to 16 channels");
+        NVDR_CHECK(p.channels == border_values.size(), "number of border values must be equal to the number of channels");
+
+        for (int i = 0; i < p.channels; ++i)
+            p.borderValues[i] = border_values[i];
+    }
+
 
     // Allocate output tensor for tex gradient.
     torch::Tensor grad_tex = torch::zeros_like(tex);
@@ -691,27 +712,27 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, std::vect
 }
 
 // Version for nearest filter mode.
-torch::Tensor texture_grad_nearest(torch::Tensor tex, torch::Tensor uv, torch::Tensor dy, int filter_mode, int boundary_mode)
+torch::Tensor texture_grad_nearest(torch::Tensor tex, torch::Tensor uv, torch::Tensor dy, int filter_mode, int boundary_mode, std::vector<float> border_values)
 {
     torch::Tensor empty_tensor;
     std::vector<torch::Tensor> empty_vector;
-    std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, std::vector<torch::Tensor> > result = texture_grad_linear_mipmap_linear(tex, uv, dy, empty_tensor, empty_tensor, TextureMipWrapper(), empty_vector, filter_mode, boundary_mode);
+    std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, std::vector<torch::Tensor> > result = texture_grad_linear_mipmap_linear(tex, uv, dy, empty_tensor, empty_tensor, TextureMipWrapper(), empty_vector, filter_mode, boundary_mode, border_values);
     return std::get<0>(result);
 }
 
 // Version for linear filter mode.
-std::tuple<torch::Tensor, torch::Tensor> texture_grad_linear(torch::Tensor tex, torch::Tensor uv, torch::Tensor dy, int filter_mode, int boundary_mode)
+std::tuple<torch::Tensor, torch::Tensor> texture_grad_linear(torch::Tensor tex, torch::Tensor uv, torch::Tensor dy, int filter_mode, int boundary_mode, std::vector<float> border_values)
 {
     torch::Tensor empty_tensor;
     std::vector<torch::Tensor> empty_vector;
-    std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, std::vector<torch::Tensor> > result = texture_grad_linear_mipmap_linear(tex, uv, dy, empty_tensor, empty_tensor, TextureMipWrapper(), empty_vector, filter_mode, boundary_mode);
+    std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, std::vector<torch::Tensor> > result = texture_grad_linear_mipmap_linear(tex, uv, dy, empty_tensor, empty_tensor, TextureMipWrapper(), empty_vector, filter_mode, boundary_mode, border_values);
     return std::tuple<torch::Tensor, torch::Tensor>(std::get<0>(result), std::get<1>(result));
 }
 
 // Version for linear-mipmap-nearest mode.
-std::tuple<torch::Tensor, torch::Tensor, std::vector<torch::Tensor> > texture_grad_linear_mipmap_nearest(torch::Tensor tex, torch::Tensor uv, torch::Tensor dy, torch::Tensor uv_da, torch::Tensor mip_level_bias, TextureMipWrapper mip_wrapper, std::vector<torch::Tensor> mip_stack, int filter_mode, int boundary_mode)
+std::tuple<torch::Tensor, torch::Tensor, std::vector<torch::Tensor> > texture_grad_linear_mipmap_nearest(torch::Tensor tex, torch::Tensor uv, torch::Tensor dy, torch::Tensor uv_da, torch::Tensor mip_level_bias, TextureMipWrapper mip_wrapper, std::vector<torch::Tensor> mip_stack, int filter_mode, int boundary_mode, std::vector<float> border_values)
 {
-    std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, std::vector<torch::Tensor> > result = texture_grad_linear_mipmap_linear(tex, uv, dy, uv_da, mip_level_bias, mip_wrapper, mip_stack, filter_mode, boundary_mode);
+    std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, std::vector<torch::Tensor> > result = texture_grad_linear_mipmap_linear(tex, uv, dy, uv_da, mip_level_bias, mip_wrapper, mip_stack, filter_mode, boundary_mode, border_values);
     return std::tuple<torch::Tensor, torch::Tensor, std::vector<torch::Tensor> >(std::get<0>(result), std::get<1>(result), std::get<4>(result));
 }
 

--- a/nvdiffrast/torch/ops.py
+++ b/nvdiffrast/torch/ops.py
@@ -10,6 +10,7 @@ import numpy as np
 import torch
 import warnings
 import _nvdiffrast_c
+from collections.abc import Sequence
 
 #----------------------------------------------------------------------------
 # Log level.
@@ -297,7 +298,7 @@ def interpolate(attr, rast, tri, rast_db=None, diff_attrs=None):
 # Linear-mipmap-linear and linear-mipmap-nearest: Mipmaps enabled.
 class _texture_func_mip(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, filter_mode, tex, uv, uv_da, mip_level_bias, mip_wrapper, filter_mode_enum, boundary_mode_enum, *mip_stack):
+    def forward(ctx, filter_mode, tex, uv, uv_da, mip_level_bias, mip_wrapper, filter_mode_enum, boundary_mode_enum, border_values, *mip_stack):
         empty = torch.tensor([])
         if uv_da is None:
             uv_da = empty
@@ -305,44 +306,44 @@ class _texture_func_mip(torch.autograd.Function):
             mip_level_bias = empty
         if mip_wrapper is None:
             mip_wrapper = _nvdiffrast_c.TextureMipWrapper()
-        out = _nvdiffrast_c.texture_fwd_mip(tex, uv, uv_da, mip_level_bias, mip_wrapper, mip_stack, filter_mode_enum, boundary_mode_enum)
+        out = _nvdiffrast_c.texture_fwd_mip(tex, uv, uv_da, mip_level_bias, mip_wrapper, mip_stack, filter_mode_enum, boundary_mode_enum, border_values)
         ctx.save_for_backward(tex, uv, uv_da, mip_level_bias, *mip_stack)
-        ctx.saved_misc = filter_mode, mip_wrapper, filter_mode_enum, boundary_mode_enum
+        ctx.saved_misc = filter_mode, mip_wrapper, filter_mode_enum, boundary_mode_enum, border_values
         return out
 
     @staticmethod
     def backward(ctx, dy):
         tex, uv, uv_da, mip_level_bias, *mip_stack = ctx.saved_tensors
-        filter_mode, mip_wrapper, filter_mode_enum, boundary_mode_enum = ctx.saved_misc
+        filter_mode, mip_wrapper, filter_mode_enum, boundary_mode_enum, border_values = ctx.saved_misc
         if filter_mode == 'linear-mipmap-linear':
-            g_tex, g_uv, g_uv_da, g_mip_level_bias, g_mip_stack = _nvdiffrast_c.texture_grad_linear_mipmap_linear(tex, uv, dy, uv_da, mip_level_bias, mip_wrapper, mip_stack, filter_mode_enum, boundary_mode_enum)
-            return (None, g_tex, g_uv, g_uv_da, g_mip_level_bias, None, None, None) + tuple(g_mip_stack)
+            g_tex, g_uv, g_uv_da, g_mip_level_bias, g_mip_stack = _nvdiffrast_c.texture_grad_linear_mipmap_linear(tex, uv, dy, uv_da, mip_level_bias, mip_wrapper, mip_stack, filter_mode_enum, boundary_mode_enum, border_values)
+            return (None, g_tex, g_uv, g_uv_da, g_mip_level_bias, None, None, None, None) + tuple(g_mip_stack)
         else: # linear-mipmap-nearest
-            g_tex, g_uv, g_mip_stack = _nvdiffrast_c.texture_grad_linear_mipmap_nearest(tex, uv, dy, uv_da, mip_level_bias, mip_wrapper, mip_stack, filter_mode_enum, boundary_mode_enum)
-            return (None, g_tex, g_uv, None, None, None, None, None) + tuple(g_mip_stack)
+            g_tex, g_uv, g_mip_stack = _nvdiffrast_c.texture_grad_linear_mipmap_nearest(tex, uv, dy, uv_da, mip_level_bias, mip_wrapper, mip_stack, filter_mode_enum, boundary_mode_enum, border_values)
+            return (None, g_tex, g_uv, None, None, None, None, None, None) + tuple(g_mip_stack)
 
 # Linear and nearest: Mipmaps disabled.
 class _texture_func(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, filter_mode, tex, uv, filter_mode_enum, boundary_mode_enum):
-        out = _nvdiffrast_c.texture_fwd(tex, uv, filter_mode_enum, boundary_mode_enum)
+    def forward(ctx, filter_mode, tex, uv, filter_mode_enum, boundary_mode_enum, border_values):
+        out = _nvdiffrast_c.texture_fwd(tex, uv, filter_mode_enum, boundary_mode_enum, border_values)
         ctx.save_for_backward(tex, uv)
-        ctx.saved_misc = filter_mode, filter_mode_enum, boundary_mode_enum
+        ctx.saved_misc = filter_mode, filter_mode_enum, boundary_mode_enum, border_values
         return out
 
     @staticmethod
     def backward(ctx, dy):
         tex, uv = ctx.saved_tensors
-        filter_mode, filter_mode_enum, boundary_mode_enum = ctx.saved_misc
+        filter_mode, filter_mode_enum, boundary_mode_enum, border_values = ctx.saved_misc
         if filter_mode == 'linear':
-            g_tex, g_uv = _nvdiffrast_c.texture_grad_linear(tex, uv, dy, filter_mode_enum, boundary_mode_enum)
-            return None, g_tex, g_uv, None, None
+            g_tex, g_uv = _nvdiffrast_c.texture_grad_linear(tex, uv, dy, filter_mode_enum, boundary_mode_enum, border_values)
+            return None, g_tex, g_uv, None, None, None
         else: # nearest
-            g_tex = _nvdiffrast_c.texture_grad_nearest(tex, uv, dy, filter_mode_enum, boundary_mode_enum)
-            return None, g_tex, None, None, None
+            g_tex = _nvdiffrast_c.texture_grad_nearest(tex, uv, dy, filter_mode_enum, boundary_mode_enum, border_values)
+            return None, g_tex, None, None, None, None
 
 # Op wrapper.
-def texture(tex, uv, uv_da=None, mip_level_bias=None, mip=None, filter_mode='auto', boundary_mode='wrap', max_mip_level=None):
+def texture(tex, uv, uv_da=None, mip_level_bias=None, mip=None, filter_mode='auto', boundary_mode='wrap', max_mip_level=None, border_values = []):
     """Perform texture sampling.
 
     All input tensors must be contiguous and reside in GPU memory. The output tensor
@@ -377,13 +378,16 @@ def texture(tex, uv, uv_da=None, mip_level_bias=None, mip=None, filter_mode='aut
                      'linear-mipmap-linear' when at least one of them is specified, these being
                      the highest-quality modes possible depending on the availability of the
                      image-space derivatives of the texture coordinates or direct mip level information.
-        boundary_mode: Valid values are 'wrap', 'clamp', 'zero', and 'cube'. If `tex` defines a
+        boundary_mode: Valid values are 'wrap', 'clamp', 'zero', 'cube', and 'values'. If `tex` defines a
                        cube map, this must be set to 'cube'. The default mode 'wrap' takes fractional
                        part of texture coordinates. Mode 'clamp' clamps texture coordinates to the
                        centers of the boundary texels. Mode 'zero' virtually extends the texture with
-                       all-zero values in all directions.
+                       all-zero values in all directions. Mode 'values' virtually extends the texture
+                       with the per-channel `border_values` in all directions (`tex_channels` must be <= 16).
         max_mip_level: If specified, limits the number of mipmaps constructed and used in mipmap-based
                        filter modes.
+        border_values: A single value or a list of per-channel border values to be used when `boundary_mode` 
+                       is `values`. The length of the list must match `tex_channels`.
 
     Returns:
         A tensor containing the results of the texture sampling with shape
@@ -416,8 +420,12 @@ def texture(tex, uv, uv_da=None, mip_level_bias=None, mip=None, filter_mode='aut
     filter_mode_enum = filter_mode_dict[filter_mode]
 
     # Convert boundary mode to internal enumeration.
-    boundary_mode_dict = {'cube': 0, 'wrap': 1, 'clamp': 2, 'zero': 3}
+    boundary_mode_dict = {'cube': 0, 'wrap': 1, 'clamp': 2, 'zero': 3, 'values': 4}
     boundary_mode_enum = boundary_mode_dict[boundary_mode]
+
+    # If border_values is a single value, wrap it in a list matching the number of channels
+    if boundary_mode == 'values' and not isinstance(border_values, Sequence):
+        border_values = [border_values] * tex.shape[-1]
 
     # Construct a mipmap if necessary.
     if 'mipmap' in filter_mode:
@@ -434,9 +442,9 @@ def texture(tex, uv, uv_da=None, mip_level_bias=None, mip=None, filter_mode='aut
 
     # Choose stub.
     if filter_mode == 'linear-mipmap-linear' or filter_mode == 'linear-mipmap-nearest':
-        return _texture_func_mip.apply(filter_mode, tex, uv, uv_da, mip_level_bias, mip_wrapper, filter_mode_enum, boundary_mode_enum, *mip_stack)
+        return _texture_func_mip.apply(filter_mode, tex, uv, uv_da, mip_level_bias, mip_wrapper, filter_mode_enum, boundary_mode_enum, border_values, *mip_stack)
     else:
-        return _texture_func.apply(filter_mode, tex, uv, filter_mode_enum, boundary_mode_enum)
+        return _texture_func.apply(filter_mode, tex, uv, filter_mode_enum, boundary_mode_enum, border_values)
 
 # Mipmap precalculation for cases where the texture stays constant.
 def texture_construct_mip(tex, max_mip_level=None, cube_mode=False):

--- a/tests/test_texture_border_values.py
+++ b/tests/test_texture_border_values.py
@@ -1,0 +1,36 @@
+import nvdiffrast.torch as dr
+import torch
+
+def main():
+    device = torch.device("cuda:0")
+
+    for minibatch_size in [1, 4]:
+        for channel_count in range(1, 18): # Channel count > 16 is expected to fail
+                for filter_mode in ['nearest', 'linear']:
+                    for per_channel_border_value in [True, False]:
+                        if per_channel_border_value:
+                            border_values = torch.rand(channel_count, dtype=torch.float32).tolist()
+                        else:
+                            border_values = torch.rand(1).item() # Channels share a border value
+
+                        tex = torch.rand(minibatch_size, 64, 64, channel_count, dtype=torch.float32, device=device)
+
+                        uvs = torch.rand(minibatch_size, 64, 64, 2, dtype=torch.float32, device=device)
+                        uvs[..., 0] = 1.1 * (2 * (torch.rand_like(uvs[..., 0]) < 0.5) - 1) # Invalidate uvs to trigger border value sampling
+
+                        # Failure is expected for more than 16 channels
+                        try:
+                            tex_samples = dr.texture(tex, uvs, filter_mode=filter_mode, boundary_mode='values', border_values=border_values)
+                        except Exception as e:
+                            assert channel_count > 16 and ("up to 16 channels" in str(e)), f"Unexpected error: {e}"
+                            continue
+
+                        assert channel_count <= 16, "Expected failure for more than 16 channels"
+
+                        for c in range(channel_count):
+                            assert torch.allclose(tex_samples[..., c], torch.tensor(border_values[c] if per_channel_border_value else border_values, device=device))
+
+    print("All tests passed.")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I am aware that no outside contributions are accepted, so please consider this a feature *proposal*.

(I'd be great if this found its way into both the internal and external code. Let me know if you need more context.)

### What?

This PR extends the `texture` function with a new border mode `values` that virtually pads a texture with user-defined values.

It works similarly to border mode `zero` but accepts either a single value shared across all channels, or a list of per-channel values.

### Why?

Nvdiffrast is commonly used in scenarios where textures represent more general features rather than colors.
The individual channels of these feature maps carry specific semantics, and the sampled features are often processed further (e.g., by a neural network). 
In this context, padding textures with zeros seems like an arbitrary choice.

Allowing users to specify the border values explicitly instead lets them define a more graceful fallback near texture boundaries.

### Validation

I've also added a small script that runs a few basic tests `tests/test_texture_border_values.py`.

### To be discussed

My implementation currently imposes a rather arbitrary maximum of 16 channels for the new mode because the border values are passed to the kernels using a fixed-size array (as part of the `TextureKernelParams` struct).
