### PR TITLE
Import torch in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 
 import setuptools
 import os
-
+import torch
 # Print an error message if there's no PyTorch installed.
 try:
     from torch.utils.cpp_extension import BuildExtension, CUDAExtension


### PR DESCRIPTION
This ensures that 'torch.utils.cpp_extension' in setup.py correctly detects the installed PyTorch when installing nvdiffrast via  pip install . --no-build-isolation after cloning the source